### PR TITLE
Fix login redirect issue

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -16,6 +16,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { apiRequest } from '@/lib/queryClient';
+import { useQueryClient } from '@tanstack/react-query';
 import { Loader2, QrCode, KeyRound, Shield, XCircle, CircleAlert } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
@@ -45,6 +46,7 @@ const setupTwoFactorSchema = z.object({
 
 export default function Login() {
   const [_, setLocation] = useLocation();
+  const queryClient = useQueryClient();
   const [isLoading, setIsLoading] = useState(false);
   const [requireTwoFactor, setRequireTwoFactor] = useState(false);
   const [requireTwoFactorSetup, setRequireTwoFactorSetup] = useState(false);
@@ -84,7 +86,7 @@ export default function Login() {
     setIsLoading(true);
     try {
       // 使用新的參數形式調用apiRequest，直接獲取JSON響應
-      const data = await apiRequest('POST', '/api/login', values);
+      const data = await apiRequest('POST', '/api/auth/login', values);
       
       // 如果需要設置二步驗證
       if (data.requireTwoFactorSetup) {
@@ -111,7 +113,9 @@ export default function Login() {
           title: '登入成功',
           description: '歡迎回來！',
         });
-        
+
+        queryClient.invalidateQueries({ queryKey: ['/api/auth/me'] });
+
         // 重定向到首頁
         setLocation('/');
       }
@@ -146,7 +150,9 @@ export default function Login() {
         title: '驗證成功',
         description: '歡迎回來！',
       });
-      
+
+      queryClient.invalidateQueries({ queryKey: ['/api/auth/me'] });
+
       // 重定向到首頁
       setLocation('/');
     } catch (error) {
@@ -185,7 +191,9 @@ export default function Login() {
         description: '二步驗證已成功設置並驗證！',
         variant: 'default'
       });
-      
+
+      queryClient.invalidateQueries({ queryKey: ['/api/auth/me'] });
+
       // 重定向到首頁
       setLocation('/');
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure `/api/auth/me` query is refetched after successful login or 2FA setup

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68450bb9246883229d1be4a361234635