### PR TITLE
Improve login security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@tanstack/react-query": "^5.80.5",
         "@types/node": "^22.15.29",
         "axios": "^1.6.8",
+        "bcryptjs": "^3.0.2",
         "class-variance-authority": "^0.7.1",
         "cloudinary": "^1.41.3",
         "clsx": "^2.1.1",
@@ -3709,6 +3710,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@tanstack/react-query": "^5.80.5",
     "@types/node": "^22.15.29",
     "axios": "^1.6.8",
+    "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "cloudinary": "^1.41.3",
     "clsx": "^2.1.1",

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,8 +7,10 @@ import agentRouter from './agent.js';
 // Facebook 相關常量定義
 export const FACEBOOK_APP_ID = process.env.FACEBOOK_APP_ID || "958057036410330"; // 設置預設值為用戶提供的 ID
 export const FACEBOOK_APP_SECRET = process.env.FACEBOOK_APP_SECRET || "";
-export const USE_FIXED_2FA_SECRET = true; // 使用固定的二步驗證密鑰
-export const FIXED_2FA_SECRET = "JBSWY3DPEHPK3PXP"; // 預設固定的二步驗證密鑰，只用於測試環境
+// 二步驗證密鑰是否固定，預設為 false，僅在測試環境可透過環境變數啟用
+export const USE_FIXED_2FA_SECRET = process.env.USE_FIXED_2FA_SECRET === 'true';
+// 固定密鑰僅供測試，可透過環境變數覆蓋
+export const FIXED_2FA_SECRET = process.env.FIXED_2FA_SECRET || 'JBSWY3DPEHPK3PXP';
 
 const app = express();
 


### PR DESCRIPTION
## Summary
- hash user passwords and compare via bcrypt
- support login attempt tracking
- expose 2FA secret config via env vars
- harden session cookie settings
- update sample data

## Testing
- `npx vitest run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845167b7dc083229138bfdda3a83e49