### PR TITLE
Fix login path and add alias

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -86,7 +86,8 @@ export default function Login() {
     setIsLoading(true);
     try {
       // 使用新的參數形式調用apiRequest，直接獲取JSON響應
-      const data = await apiRequest('POST', '/api/auth/login', values);
+      // 後端 server.js 使用 /api/login 作為登入路徑
+      const data = await apiRequest('POST', '/api/login', values);
       
       // 如果需要設置二步驗證
       if (data.requireTwoFactorSetup) {

--- a/server.js
+++ b/server.js
@@ -18,14 +18,18 @@ const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
 app.use(express.json());
 
 // ✅ 簡易登入 API
-app.post('/api/login', (req, res) => {
+function simpleAuth(req, res) {
   const { username, password } = req.body;
   if (username === 'chris' && password === 'Zxc777') {
     return res.status(200).json({ success: true });
   } else {
     return res.status(401).json({ success: false, message: '帳號或密碼錯誤' });
   }
-});
+}
+
+// 支援兩種路徑，避免前端路徑不一致
+app.post('/api/login', simpleAuth);
+app.post('/api/auth/login', simpleAuth);
 
 // ✅ Chat 聊天 API
 app.post('/api/agent/chat', async (req, res) => {


### PR DESCRIPTION
## Summary
- support legacy `/api/auth/login` endpoint in server
- document correct login path in the client

## Testing
- `npm test -- -t queryClient`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68453ac85a3c83228a98cf576263966d