### PR TITLE
Fix login redirect by caching session and running tests

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -149,7 +149,7 @@ export default function Login() {
     setTwoFactorError(false);
     try {
       // 使用apiRequest直接獲取JSON響應
-      await apiRequest('POST', '/api/auth/verify-2fa', {
+      const data = await apiRequest('POST', '/api/auth/verify-2fa', {
         userId,
         code: values.code
       });
@@ -160,7 +160,14 @@ export default function Login() {
         description: '歡迎回來！',
       });
 
-      queryClient.invalidateQueries({ queryKey: ['/api/auth/me'] });
+      if (data && data.userId) {
+        queryClient.setQueryData(['/api/auth/me'], {
+          username: data.username,
+          userId: data.userId,
+        });
+      } else {
+        await queryClient.invalidateQueries({ queryKey: ['/api/auth/me'] });
+      }
 
       // 重定向到首頁
       setLocation('/');
@@ -189,7 +196,7 @@ export default function Login() {
     setTwoFactorError(false);
     try {
       // 使用首次登入的二步驗證設置 API，直接獲取JSON響應
-      await apiRequest('POST', '/api/auth/setup-2fa', {
+      const data = await apiRequest('POST', '/api/auth/setup-2fa', {
         userId,
         code: values.code
       });
@@ -201,7 +208,11 @@ export default function Login() {
         variant: 'default'
       });
 
-      queryClient.invalidateQueries({ queryKey: ['/api/auth/me'] });
+      if (data && data.user) {
+        queryClient.setQueryData(['/api/auth/me'], data.user);
+      } else {
+        await queryClient.invalidateQueries({ queryKey: ['/api/auth/me'] });
+      }
 
       // 重定向到首頁
       setLocation('/');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "start": "node server.js",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -500,7 +500,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // 更新最後登入時間
       await storage.updateUser(userId, { lastLoginAt: new Date() });
       
-      res.json({ message: "驗證成功", userId });
+      res.json({
+        message: "驗證成功",
+        userId,
+        username: user.username
+      });
     } catch (error) {
       if (error instanceof z.ZodError) {
         return res.status(400).json({ message: error.errors });


### PR DESCRIPTION
## Summary
- ensure vitest runs in non-interactive mode
- keep user session data in query cache after verifying 2FA
- send username in verify-2fa API response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845b844be148322b2a67e0b5ef75511